### PR TITLE
refactor: turn it into a crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,21 @@
 [package]
-name = "dcl-auth-websocket"
+name = "dcl-crypto-middleware-rs"
 version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dcl-crypto = "0.1.0"
-fastrand = "1.9.0"
-futures-util = "0.3.28"
-tokio = { version = "1.28.0" }
-warp = "0.3.5"
+async-trait = {version = "0.1.68", optional = true}
+dcl-crypto = "0.2.1"
+fastrand = { version = "1.9.0", optional = true }
+log = "0.4.17"
+tokio = { version = "1.28.0", optional = true }
+
+[dev-dependencies]
+serde_json = "1.0"
+
+[features]
+default = ["ws", "signed_fetch"]
+ws = ["dep:fastrand", "dep:async-trait", "dep:tokio"]
+signed_fetch = []

--- a/README.md
+++ b/README.md
@@ -1,27 +1,10 @@
-# dcl-auth-websocket
+# Decentraland Authentication Middleware for Rust
 
-Authenticate a WebSocket Connection using the Decentraland's Authchain on a [warp](https://github.com/seanmonstar/warp) server
+Utils to authenticate a DCL user using the [Authchain](https://docs.decentraland.org/contributor/auth/authchain)
 
-## Example
-```rust
-use dcl_crypto::{AuthChain, Authenticator};
-use futures_util::{SinkExt, StreamExt};
-use tokio::time::{timeout, Duration};
-use warp::{
-    ws::{Message, WebSocket},
-    Filter,
-};
-use dcl_auth_websocket::authenticate_dcl_user
+This crate aims to provide all the utilities needed for authenticating an user when creating a new Rust service. 
+It can be compared to this [library](https://github.com/decentraland/decentraland-crypto-middleware) for TS
 
-#[tokio::main]
-async fn main() {
-    let routes = warp::path("ws")
-        .and(warp::ws())
-        .map(|ws: warp::ws::Ws| ws.on_upgrade(|ws| async move {
-            let (ws, user_address) = authenticate_dcl_user(ws, 30).await;
-            //....
-        }));
-
-    warp::serve(routes).run(([127, 0, 0, 1], 3030)).await;
-}
-```
+It provides:
+- A mechanism for authenticating a WS conneciton. 
+- A verification function for signed fetches to be called as a middleware on a HTTP Server.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,77 +1,30 @@
-use dcl_crypto::{Address, AuthChain, Authenticator};
-use futures_util::{SinkExt, StreamExt};
-use tokio::time::{timeout as timeout_fn, Duration};
-use warp::ws::{Message, WebSocket};
+#[cfg(feature = "signed_fetch")]
+pub mod signed_fetch;
+#[cfg(feature = "ws")]
+pub mod ws;
 
-pub enum AuthenticationErrors {
-    FailedToSendChallenge,
-    WrongSignature,
-    Timeout,
-    NotTextMessage,
-    UnexpectedError(Box<dyn std::error::Error + Send + Sync>),
-}
-
-/// Authenticate a WebSocket Connection using the Decentraland's Authchain on a [`warp`] server
-///
-/// The function will send a signature challenge and waits for the client's signed authchain.
-///
-/// The function could fail:
-/// * if the client cannot receive the challenge
-/// * if the timeout expires
-/// * if the signature is not valid
-/// * if the client sends a message that it cannot be turned into a string (json)
-/// * if an error occurs on the connection
-///
-/// ## Arguments
-/// * `ws`: [`warp::ws::WebSocket`] given by the [`warp::ws::Ws`] `on_upgrade` closure
-/// * `timeout`: Amount of seconds to wait for the client to send the auth chain
-///
-pub async fn authenticate_dcl_user(
-    ws: WebSocket,
-    timeout: u64,
-) -> Result<(WebSocket, Address), AuthenticationErrors> {
-    let authenticator = Authenticator::new();
-    let (mut ws_write, mut ws_read) = ws.split();
-
-    let message_to_be_firmed = format!("signature_challenge_{}", fastrand::u32(..));
-
-    if ws_write
-        .send(Message::text(&message_to_be_firmed))
-        .await
-        .is_err()
-    {
-        return Err(AuthenticationErrors::FailedToSendChallenge);
-    }
-
-    match timeout_fn(Duration::from_secs(timeout), ws_read.next()).await {
-        Ok(client_response) => {
-            let response = client_response.unwrap().unwrap();
-            if let Ok(auth_chain) = response.to_str() {
-                let auth_chain = AuthChain::from_json(auth_chain).unwrap();
-                if let Ok(address) = authenticator
-                    .verify_signature(&auth_chain, &message_to_be_firmed)
-                    .await
-                {
-                    let address = address.to_owned();
-                    match ws_write.reunite(ws_read) {
-                        Ok(ws) => Ok((ws, address)),
-                        Err(err) => Err(AuthenticationErrors::UnexpectedError(Box::new(err))),
-                    }
-                } else if let Err(err) = ws_write.close().await {
-                    Err(AuthenticationErrors::UnexpectedError(Box::new(err)))
-                } else {
-                    Err(AuthenticationErrors::WrongSignature)
-                }
-            } else {
-                Err(AuthenticationErrors::NotTextMessage)
-            }
-        }
-        Err(_) => {
-            if let Err(err) = ws_write.close().await {
-                Err(AuthenticationErrors::UnexpectedError(Box::new(err)))
-            } else {
-                Err(AuthenticationErrors::Timeout)
-            }
-        }
-    }
+#[cfg(test)]
+fn create_test_identity() -> dcl_crypto::Identity {
+    dcl_crypto::Identity::from_json(
+        r#"{
+       "ephemeralIdentity": {
+         "address": "0x84452bbFA4ca14B7828e2F3BBd106A2bD495CD34",
+         "publicKey": "0x0420c548d960b06dac035d1daf826472eded46b8b9d123294f1199c56fa235c89f2515158b1e3be0874bfb15b42d1551db8c276787a654d0b8d7b4d4356e70fe42",
+         "privateKey": "0xbc453a92d9baeb3d10294cbc1d48ef6738f718fd31b4eb8085efe7b311299399"
+       },
+       "expiration": "3021-10-16T22:32:29.626Z",
+       "authChain": [
+         {
+           "type": "SIGNER",
+           "payload": "0x7949f9f239d1a0816ce5eb364a1f588ae9cc1bf5",
+           "signature": ""
+         },
+         {
+           "type": "ECDSA_EPHEMERAL",
+           "payload": "Decentraland Login\nEphemeral address: 0x84452bbFA4ca14B7828e2F3BBd106A2bD495CD34\nExpiration: 3021-10-16T22:32:29.626Z",
+           "signature": "0x39dd4ddf131ad2435d56c81c994c4417daef5cf5998258027ef8a1401470876a1365a6b79810dc0c4a2e9352befb63a9e4701d67b38007d83ffc4cd2b7a38ad51b"
+         }
+       ]
+      }"#,
+    ).unwrap()
 }

--- a/src/signed_fetch.rs
+++ b/src/signed_fetch.rs
@@ -1,0 +1,393 @@
+// This was built following the https://adr.decentraland.org/adr/ADR-44
+use dcl_crypto::{Address, AuthChain, AuthLink, Authenticator, Web3Transport};
+use std::{
+    collections::HashMap,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+const AUTH_CHAIN_HEADER_PREFIX: &str = "x-identity-auth-chain-";
+const AUTH_TIMESTAMP_HEADER: &str = "x-identity-timestamp";
+const AUTH_METADATA_HEADER: &str = "x-identity-metadata";
+const DEFAULT_EXPIRATION: u32 = 1000 * 60;
+
+/// Errors returned by [`verify`]
+#[derive(Debug)]
+pub enum AuthMiddlewareError {
+    /// A provided header doesn't meet the requirements to be a valid AuthLink of the Authchain
+    NotAuthLink,
+    /// The provided timestamp within headers is not valid. It's empty or not a number
+    InvalidTimestamp,
+    /// The provided metadata within headers is not valid. It's empty.
+    InvalidMetadata,
+    /// The request is unauthorized to continue because it expires or the signature is not valid
+    Unauthotized,
+}
+
+/// Options that must be provided to [`verify`] function
+pub struct VerificationOptions<T> {
+    /// Authenticator must be provided by the crate's user
+    authenticator: Authenticator<T>,
+    /// Optional expiration time. The default is `1000 * 60` ms
+    expirtation: Option<u32>,
+}
+
+/// Verify the Authchain headers provided within request to identify a Decentraland user
+///
+/// The function will extract the authchain from the headers and verify them to get the user who sent the request
+///
+/// ## Arguments
+/// * method: the request's HTTP method
+/// * path: the request's path
+/// * headers: the request's headers mapped as a `HashMap<String, String>`
+/// * options: [`VerificationOptions`]
+///
+pub async fn verify<T: Web3Transport>(
+    method: &str,
+    path: &str,
+    headers: HashMap<String, String>,
+    options: VerificationOptions<T>,
+) -> Result<Address, AuthMiddlewareError> {
+    let auth_chain = extract_auth_chain(&headers)?;
+
+    let timestamp = if let Some(ts) = headers.get(AUTH_TIMESTAMP_HEADER) {
+        ts
+    } else {
+        return Err(AuthMiddlewareError::InvalidTimestamp);
+    };
+
+    let ts_number = verify_ts(timestamp)?;
+
+    let metadata = if let Some(metadata) = headers.get(AUTH_METADATA_HEADER) {
+        metadata
+    } else {
+        return Err(AuthMiddlewareError::InvalidMetadata);
+    };
+
+    let payload = create_payload(&method.to_ascii_lowercase(), path, timestamp, metadata);
+
+    let exp = options.expirtation.unwrap_or(DEFAULT_EXPIRATION);
+
+    verify_expirtation(ts_number, exp)?;
+
+    verify_sign(options.authenticator, auth_chain, &payload).await
+}
+
+fn extract_auth_chain(headers: &HashMap<String, String>) -> Result<AuthChain, AuthMiddlewareError> {
+    let mut index = 0;
+
+    let mut auth_links = vec![];
+    while let Some(header) = headers.get(&format!("{}{}", AUTH_CHAIN_HEADER_PREFIX, index)) {
+        if let Ok(auth_link) = AuthLink::parse(header) {
+            auth_links.push(auth_link);
+        } else {
+            return Err(AuthMiddlewareError::NotAuthLink);
+        }
+
+        index += 1;
+    }
+
+    Ok(AuthChain::from(auth_links))
+}
+
+fn verify_ts(ts: &str) -> Result<u128, AuthMiddlewareError> {
+    ts.parse::<u128>()
+        .map_err(|_| AuthMiddlewareError::InvalidTimestamp)
+}
+
+fn create_payload(method: &str, path: &str, timestamp: &str, metadata: &str) -> String {
+    [method, path, timestamp, metadata].join(":")
+}
+
+async fn verify_sign<T: Web3Transport>(
+    authenticator: Authenticator<T>,
+    auth_chain: AuthChain,
+    payload: &str,
+) -> Result<Address, AuthMiddlewareError> {
+    Ok(authenticator
+        .verify_signature(&auth_chain, payload)
+        .await
+        .map_err(|_| AuthMiddlewareError::Unauthotized)?
+        .to_owned())
+}
+
+fn verify_expirtation(ts: u128, expiration: u32) -> Result<(), AuthMiddlewareError> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("not unix epoch time")
+        .as_millis();
+
+    let expected = ts + expiration as u128;
+
+    if expected < now {
+        return Err(AuthMiddlewareError::Unauthotized);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use crate::create_test_identity;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn verify_should_return_err() {
+        let mapped_headers = HashMap::from([
+            (
+                "x-identity-auth-chain-0".to_string(),
+                r#"{"type": "SIGNER", "payload": "0x7949f9F239D1a0816ce5Eb364A1F588AE9Cc1Bf5","signature": ""}"#.to_string(),
+            ),
+            (
+                "x-identity-auth-chain-1".to_string(),
+                r#"{"type":"ECDSA_EPHEMERAL","payload":"Decentraland Login\nEphemeral address: 0x84452bbFA4ca14B7828e2F3BBd106A2bD495CD34\nExpiration: 3021-10-16T22:32:29.626Z","signature":"0x39dd4ddf131ad2435d56c81c994c4417daef5cf5998258027ef8a1401470876a1365a6b79810dc0c4a2e9352befb63a9e4701d67b38007d83ffc4cd2b7a38ad51b"}"#.to_string(),
+            ),
+            (
+                "x-identity-auth-chain-2".to_string(),
+                r#"{"type":"ECDSA_SIGNED_ENTITY","payload":"get:/api/events:1684936391789:{}","signature":"0xc1511b724b986925896fa7f67f1004b1dbca331f32bea806456ea205904a70f723d1ecb9c0f8c52a930fccb2d2eb61ca715120d57b3226d66d8ce5e63567f27c1c"}"#.to_string(),
+            ),
+            ("x-identity-timestamp".to_string(), "".to_string()),
+            ("x-identity-metadata".to_string(), "{}".to_string()),
+        ]);
+
+        assert!(matches!(
+            verify(
+                "GET",
+                "/",
+                mapped_headers,
+                VerificationOptions {
+                    authenticator: Authenticator::new(),
+                    expirtation: None,
+                },
+            )
+            .await
+            .unwrap_err(),
+            AuthMiddlewareError::InvalidTimestamp
+        ));
+
+        let mapped_headers = HashMap::from([
+            (
+                "x-identity-auth-chain-0".to_string(),
+                r#"{"type": "SIGNER", "payload": "0x7949f9F239D1a0816ce5Eb364A1F588AE9Cc1Bf5","signature": ""}"#.to_string(),
+            ),
+            (
+                "x-identity-auth-chain-1".to_string(),
+                r#"{"type":"ECDSA_EPHEMERAL","payload":"Decentraland Login\nEphemeral address: 0x84452bbFA4ca14B7828e2F3BBd106A2bD495CD34\nExpiration: 3021-10-16T22:32:29.626Z","signature":"0x39dd4ddf131ad2435d56c81c994c4417daef5cf5998258027ef8a1401470876a1365a6b79810dc0c4a2e9352befb63a9e4701d67b38007d83ffc4cd2b7a38ad51b"}"#.to_string(),
+            ),
+            (
+                "x-identity-auth-chain-2".to_string(),
+                r#"{"type":"ECDSA_SIGNED_ENTITY","payload":"get:/api/events:1684936391789:{}","signature":"0xc1511b724b986925896fa7f67f1004b1dbca331f32bea806456ea205904a70f723d1ecb9c0f8c52a930fccb2d2eb61ca715120d57b3226d66d8ce5e63567f27c1c"}"#.to_string(),
+            ),
+            ("x-identity-metadata".to_string(), "{}".to_string()),
+        ]);
+
+        assert!(matches!(
+            verify(
+                "GET",
+                "/",
+                mapped_headers,
+                VerificationOptions {
+                    authenticator: Authenticator::new(),
+                    expirtation: None,
+                },
+            )
+            .await
+            .unwrap_err(),
+            AuthMiddlewareError::InvalidTimestamp
+        ));
+
+        let mapped_headers = HashMap::from([
+            (
+                "x-identity-auth-chain-0".to_string(),
+                r#"{"type": "SIGNER", "payload": "0x7949f9F239D1a0816ce5Eb364A1F588AE9Cc1Bf5","signature": ""}"#.to_string(),
+            ),
+            (
+                "x-identity-auth-chain-1".to_string(),
+                r#"{"type":"ECDSA_EPHEMERAL","payload":"Decentraland Login\nEphemeral address: 0x84452bbFA4ca14B7828e2F3BBd106A2bD495CD34\nExpiration: 3021-10-16T22:32:29.626Z","signature":"0x39dd4ddf131ad2435d56c81c994c4417daef5cf5998258027ef8a1401470876a1365a6b79810dc0c4a2e9352befb63a9e4701d67b38007d83ffc4cd2b7a38ad51b"}"#.to_string(),
+            ),
+            (
+                "x-identity-auth-chain-2".to_string(),
+                r#"{"type":"ECDSA_SIGNED_ENTITY","payload":"get:/api/events:1684936391789:{}","signature":"0xc1511b724b986925896fa7f67f1004b1dbca331f32bea806456ea205904a70f723d1ecb9c0f8c52a930fccb2d2eb61ca715120d57b3226d66d8ce5e63567f27c1c"}"#.to_string(),
+            ),
+            ("x-identity-timestamp".to_string(), "1684937236359".to_string()),
+        ]);
+
+        assert!(matches!(
+            verify(
+                "GET",
+                "/",
+                mapped_headers,
+                VerificationOptions {
+                    authenticator: Authenticator::new(),
+                    expirtation: None,
+                },
+            )
+            .await
+            .unwrap_err(),
+            AuthMiddlewareError::InvalidMetadata
+        ));
+
+        let past_timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .checked_sub(Duration::from_secs(120))
+            .unwrap()
+            .as_millis();
+
+        let mapped_headers = HashMap::from([
+                (
+                    "x-identity-auth-chain-0".to_string(),
+                    r#"{"type": "SIGNER", "payload": "0x7949f9F239D1a0816ce5Eb364A1F588AE9Cc1Bf5","signature": ""}"#.to_string(),
+                ),
+                (
+                    "x-identity-auth-chain-1".to_string(),
+                    r#"{"type":"ECDSA_EPHEMERAL","payload":"Decentraland Login\nEphemeral address: 0x84452bbFA4ca14B7828e2F3BBd106A2bD495CD34\nExpiration: 3021-10-16T22:32:29.626Z","signature":"0x39dd4ddf131ad2435d56c81c994c4417daef5cf5998258027ef8a1401470876a1365a6b79810dc0c4a2e9352befb63a9e4701d67b38007d83ffc4cd2b7a38ad51b"}"#.to_string(),
+                ),
+                (
+                    "x-identity-auth-chain-2".to_string(),
+                    r#"{"type":"ECDSA_SIGNED_ENTITY","payload":"get:/api/events:1684936391789:{}","signature":"0xc1511b724b986925896fa7f67f1004b1dbca331f32bea806456ea205904a70f723d1ecb9c0f8c52a930fccb2d2eb61ca715120d57b3226d66d8ce5e63567f27c1c"}"#.to_string(),
+                ),
+                ("x-identity-timestamp".to_string(), format!("{}", past_timestamp)),
+                ("x-identity-metadata".to_string(), "{}".to_string()),
+            ]);
+
+        assert!(matches!(
+            verify(
+                "GET",
+                "/",
+                mapped_headers,
+                VerificationOptions {
+                    authenticator: Authenticator::new(),
+                    expirtation: None,
+                },
+            )
+            .await
+            .unwrap_err(),
+            AuthMiddlewareError::Unauthotized
+        ));
+    }
+
+    #[test]
+    fn extract_authchain_should_return_ok() {
+        let mapped_headers = HashMap::from([
+            (
+                "x-identity-auth-chain-0".to_string(),
+                r#"{"type": "SIGNER", "payload": "0x7949f9F239D1a0816ce5Eb364A1F588AE9Cc1Bf5","signature": ""}"#.to_string(),
+            ),
+            (
+                "x-identity-auth-chain-1".to_string(),
+                r#"{"type":"ECDSA_EPHEMERAL","payload":"Decentraland Login\nEphemeral address: 0x84452bbFA4ca14B7828e2F3BBd106A2bD495CD34\nExpiration: 3021-10-16T22:32:29.626Z","signature":"0x39dd4ddf131ad2435d56c81c994c4417daef5cf5998258027ef8a1401470876a1365a6b79810dc0c4a2e9352befb63a9e4701d67b38007d83ffc4cd2b7a38ad51b"}"#.to_string(),
+            ),
+            (
+                "x-identity-auth-chain-2".to_string(),
+                r#"{"type":"ECDSA_SIGNED_ENTITY","payload":"get:/api/events:1684936391789:{}","signature":"0xc1511b724b986925896fa7f67f1004b1dbca331f32bea806456ea205904a70f723d1ecb9c0f8c52a930fccb2d2eb61ca715120d57b3226d66d8ce5e63567f27c1c"}"#.to_string(),
+            ),
+            ("x-identity-timestamp".to_string(), "1684937236359".to_string()),
+            ("x-identity-metadata".to_string(), "{}".to_string()),
+        ]);
+
+        assert!(extract_auth_chain(&mapped_headers).is_ok())
+    }
+
+    #[test]
+    fn extract_authchain_should_return_err() {
+        let mapped_headers = HashMap::from([
+            (
+                "x-identity-auth-chain-0".to_string(),
+                r#"{"type": "SIGNER", "payload": "0x7949f9F239D1a0816ce5Eb364A1F588AE9Cc1Bf5","signature": ""}"#.to_string(),
+            ),
+            (
+                "x-identity-auth-chain-1".to_string(),
+                r#"{}"#.to_string(),
+            ),
+            (
+                "x-identity-auth-chain-2".to_string(),
+                r#"{"type":"ECDSA_SIGNED_ENTITY","payload":"get:/api/events:1684936391789:{}","signature":"0xc1511b724b986925896fa7f67f1004b1dbca331f32bea806456ea205904a70f723d1ecb9c0f8c52a930fccb2d2eb61ca715120d57b3226d66d8ce5e63567f27c1c"}"#.to_string(),
+            ),
+            ("x-identity-timestamp".to_string(), "1684937236359".to_string()),
+            ("x-identity-metadata".to_string(), "{}".to_string()),
+        ]);
+
+        assert!(matches!(
+            extract_auth_chain(&mapped_headers).unwrap_err(),
+            AuthMiddlewareError::NotAuthLink
+        ))
+    }
+
+    #[test]
+    fn verify_ts_should_return_ok() {
+        let ts = "1684869538587";
+
+        assert_eq!(verify_ts(ts).unwrap(), 1684869538587)
+    }
+
+    #[test]
+    fn verify_ts_should_return_err() {
+        let ts = "1684869538d587";
+
+        assert!(matches!(
+            verify_ts(ts).unwrap_err(),
+            AuthMiddlewareError::InvalidTimestamp
+        ));
+    }
+
+    #[tokio::test]
+    async fn verify_sign_should_return_ok() {
+        let identity = create_test_identity();
+        let signed_fetch = identity.sign_payload("get:/api/events:1684869538587:{}");
+
+        let address = verify_sign(
+            Authenticator::new(),
+            signed_fetch,
+            "get:/api/events:1684869538587:{}",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            address.to_string(),
+            "0x7949f9f239d1a0816ce5eb364a1f588ae9cc1bf5"
+        )
+    }
+
+    #[tokio::test]
+    async fn verify_sign_should_return_err() {
+        let identity = create_test_identity();
+        let signed_fetch = identity.sign_payload("get:/api/events:1684869538587:{}");
+
+        assert!(matches!(
+            verify_sign(
+                Authenticator::new(),
+                signed_fetch,
+                "get:/api/events:1684869538687:{}",
+            )
+            .await
+            .unwrap_err(),
+            AuthMiddlewareError::Unauthotized
+        ));
+    }
+
+    #[test]
+    fn expiration_should_return_ok() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis();
+
+        assert!(verify_expirtation(now, DEFAULT_EXPIRATION).is_ok());
+    }
+
+    #[test]
+    fn expiration_should_return_error() {
+        let past = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .checked_sub(Duration::from_secs(120))
+            .unwrap()
+            .as_millis();
+
+        assert!(verify_expirtation(past, DEFAULT_EXPIRATION).is_err());
+    }
+}

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -1,0 +1,182 @@
+use dcl_crypto::{Address, AuthChain, Authenticator};
+use std::time::Duration;
+
+#[derive(Debug)]
+/// Errors returned by [`authenticate_dcl_user`]
+pub enum WSAuthError {
+    /// Failed while sending the signature challenge to the client
+    FailedToSendChallenge,
+    /// Signature provided by the client is invalid
+    InvalidSignature,
+    /// The time elapsed without signed challenge
+    Timeout,
+    /// The messaged sent by the client is not a valid authchain
+    InvalidMessage,
+    /// Error on the connection
+    ConnectionError,
+}
+
+/// Authenticate a WebSocket Connection using the Decentraland's Authchain on a type that implements [`AuthenticatedWebSocket`]
+///
+/// The function will send a signature challenge and waits for the client's signed authchain.
+///
+/// The function could fail:
+/// * if the client cannot receive the challenge
+/// * if the signature is not valid
+/// * if the timeout expires
+/// * if the client sends a message that it cannot be turned into a string (json)
+/// * if an error occurs on the connection
+///
+/// ## Arguments
+/// * `ws`: type implementing [`AuthenticatedWebSocket`]
+/// * `timeout`: Amount of seconds to wait for the client to send the auth chain
+///
+pub async fn authenticate_dcl_user<T: AuthenticatedWebSocket>(
+    ws: &mut T,
+    timeout: u64,
+) -> Result<Address, WSAuthError> {
+    let authenticator = Authenticator::new();
+
+    let message_to_be_firmed = format!("signature_challenge_{}", fastrand::u32(..));
+
+    ws.send_signature_challenge(&message_to_be_firmed)
+        .await
+        .map_err(|_| WSAuthError::FailedToSendChallenge)?;
+
+    match tokio::time::timeout(Duration::from_secs(timeout), ws.receive_signed_challenge()).await {
+        Ok(Ok(client_response)) => {
+            let auth_chain = AuthChain::from_json(&client_response).map_err(|e| {
+                log::debug!("Invalid auth_chain: {client_response}: {e:?}");
+                WSAuthError::InvalidMessage
+            })?;
+            authenticator
+                .verify_signature(&auth_chain, &message_to_be_firmed)
+                .await
+                .map(|address| address.to_owned())
+                .map_err(|e| {
+                    log::debug!("Invalid signature: {e:?}");
+                    WSAuthError::InvalidSignature
+                })
+        }
+        Ok(Err(_)) => Err(WSAuthError::ConnectionError),
+        Err(_) => Err(WSAuthError::Timeout),
+    }
+}
+
+/// Trait that should be implemented by the type in charge of handling the websocket connection
+#[async_trait::async_trait]
+pub trait AuthenticatedWebSocket {
+    type Error;
+    /// Sends the signature challenge to the client
+    async fn send_signature_challenge(&self, challenge: &str) -> Result<(), Self::Error>;
+
+    /// Receives the authchain with signed challenge
+    async fn receive_signed_challenge(&mut self) -> Result<String, Self::Error>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::create_test_identity;
+
+    enum ReplyType {
+        InvalidMessageError,
+        InvalidSignatureError,
+        TimeoutError,
+        AuthChain,
+    }
+
+    // Mock for simulating a connection
+    struct InMemory {
+        sender: tokio::sync::mpsc::Sender<String>,
+        receiver: tokio::sync::mpsc::Receiver<String>,
+        reply_type: ReplyType,
+    }
+
+    impl InMemory {
+        fn new(reply_type: ReplyType) -> Self {
+            let chann = tokio::sync::mpsc::channel(1);
+            Self {
+                sender: chann.0,
+                receiver: chann.1,
+                reply_type,
+            }
+        }
+    }
+
+    // Mock for simulating a connection
+    #[async_trait::async_trait]
+    impl AuthenticatedWebSocket for InMemory {
+        type Error = String;
+        async fn send_signature_challenge(&self, challenge: &str) -> Result<(), Self::Error> {
+            self.sender.send(challenge.to_string()).await.unwrap();
+            Ok(())
+        }
+
+        async fn receive_signed_challenge(&mut self) -> Result<String, Self::Error> {
+            match self.receiver.recv().await {
+                Some(challenge) => match &self.reply_type {
+                    ReplyType::AuthChain => {
+                        let identity = create_test_identity();
+                        let chain = identity.sign_payload(challenge);
+                        Ok(serde_json::to_string(&chain).unwrap())
+                    }
+                    ReplyType::InvalidMessageError => Ok(String::from("")),
+                    ReplyType::TimeoutError => {
+                        tokio::time::sleep(Duration::from_secs(2)).await; // 1 second passed to the func
+                        Ok(String::from(""))
+                    }
+                    ReplyType::InvalidSignatureError => {
+                        let identity = create_test_identity();
+                        let chain = identity.sign_payload("challenge");
+                        Ok(serde_json::to_string(&chain).unwrap())
+                    }
+                },
+                None => Err("Error".to_string()),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn authtentication_should_return_ok() {
+        let mut in_memory_connection = InMemory::new(ReplyType::AuthChain);
+        let address = authenticate_dcl_user(&mut in_memory_connection, 1)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            address.to_string(),
+            "0x7949f9f239d1a0816ce5eb364a1f588ae9cc1bf5"
+        )
+    }
+
+    #[tokio::test]
+    async fn authtentication_should_return_err() {
+        let mut in_memory_connection = InMemory::new(ReplyType::InvalidMessageError);
+
+        assert!(matches!(
+            authenticate_dcl_user(&mut in_memory_connection, 1)
+                .await
+                .unwrap_err(),
+            WSAuthError::InvalidMessage
+        ));
+
+        let mut in_memory_connection = InMemory::new(ReplyType::TimeoutError);
+
+        assert!(matches!(
+            authenticate_dcl_user(&mut in_memory_connection, 1)
+                .await
+                .unwrap_err(),
+            WSAuthError::Timeout
+        ));
+
+        let mut in_memory_connection = InMemory::new(ReplyType::InvalidSignatureError);
+
+        assert!(matches!(
+            authenticate_dcl_user(&mut in_memory_connection, 1)
+                .await
+                .unwrap_err(),
+            WSAuthError::InvalidSignature
+        ))
+    }
+}


### PR DESCRIPTION
This PR:
- generalizes the function to authenticate a WebSocket connection
- adds a function to be used as a middleware for signed fetches
- turn it into a crate